### PR TITLE
tell about auto-resolving lsp-sourcekit-executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ If you don't use `use-package`:
           "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp")))
 ```
 
-(On macOS, you can get the path to the SourceKit-LSP executable by running `xcrun --find sourcekit-lsp` in Terminal.)
+On macOS, you can get the path to the SourceKit-LSP executable by running `xcrun --find sourcekit-lsp` in Terminal. This also works to populate the path, if your emacs shell is configured correctly: 
+
+```elisp
+(setq lsp-sourcekit-executable (string-trim-right (shell-command-to-string "xcrun --find sourcekit-lsp") "\n")))
+```
 
 - Finally, if you want to enable `lsp` automatically whenever you visit a `.swift` file:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you don't use `use-package`:
 On macOS, you can get the path to the SourceKit-LSP executable by running `xcrun --find sourcekit-lsp` in Terminal. This also works to populate the path, if your emacs shell is configured correctly: 
 
 ```elisp
-(setq lsp-sourcekit-executable (string-trim-right (shell-command-to-string "xcrun --find sourcekit-lsp") "\n")))
+(setq lsp-sourcekit-executable (string-trim (shell-command-to-string "xcrun --find sourcekit-lsp")))
 ```
 
 - Finally, if you want to enable `lsp` automatically whenever you visit a `.swift` file:


### PR DESCRIPTION
I think I'm actually resolving the path lazily with my settings so that this doesn't increase startup time:

```
(use-package swift-mode
  :hook (swift-mode . lsp-deferred))
(use-package lsp-sourcekit
  :after (swift-mode lsp-mode)
  :config
  (setq lsp-sourcekit-executable (string-trim-right (shell-command-to-string "xcrun --find sourcekit-lsp") "\n")))
```