### PR TITLE
Improve CI with Eask

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,45 +3,34 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  unix-test:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
           - 26.1
           - 26.2
           - 26.3
           - 27.1
+          - 27.2
+          - 28.1
           - snapshot
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: purcell/setup-emacs@master
+      - uses: jcs090218/setup-emacs@master
         with:
           version: ${{ matrix.emacs-version }}
 
-      - name: Run tests
-        run: make ci
-
-  windows-test:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        emacs-version:
-          - 26.1
-          - 26.2
-          - 26.3
-          - 27.1
-          - snapshot
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: jcs090218/setup-emacs-windows@master
+      - uses: actions/setup-node@v2
         with:
-          version: ${{ matrix.emacs-version }}
+          node-version: '16'
+
+      - uses: emacs-eask/setup-eask@master
+        with:
+          version: 'snapshot'
 
       - name: Run tests
         run: make ci

--- a/Eask
+++ b/Eask
@@ -1,0 +1,15 @@
+(package "lsp-sourcekit"
+         "0.1"
+         "sourcekit-lsp client for lsp-mode")
+
+(package-file "lsp-sourcekit.el")
+
+(files "*.el")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs" "25.1")
+(depends-on "lsp-mode")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,26 @@
 .PHONY: all compile clean
 
 EMACS ?= emacs
-CASK ?= cask
+EASK ?= eask
 
 LSP-SOURCEKIT-GENERAL := lsp-sourcekit.el
 
-all:
-	$(CASK) build
+ci: clean build compile checkdoc lint
 
 build:
-	$(CASK) install
+	$(EASK) package
+	$(EASK) install
 
 compile:
 	@echo "Compiling..."
-	@$(CASK) $(EMACS) -Q --batch \
-		-l test/windows-bootstrap.el \
-		-L . \
-		--eval '(setq byte-compile-error-on-warn t)' \
-		-f batch-byte-compile *.el
+	@$(EASK) compile
 
-ci: CASK=
-ci: clean compile
+checkdoc:
+	$(EASK) checkdoc
+
+lint:
+	@echo "package linting..."
+	$(EASK) lint
 
 clean:
-	rm -rf .cask *.elc
+	$(EASK) clean-all


### PR DESCRIPTION
I have recently created a tool named [Eask](https://github.com/emacs-eask/eask). It's similar to Cask, but it has a better cross-platform capability. It tests your package/configuration in a much more consistent way.

Related PR already applied:

* https://github.com/emacs-lsp/lsp-ui/pull/700
* https://github.com/emacs-lsp/dap-mode/pull/596
* https://github.com/emacs-lsp/lsp-dart/pull/158

Changes from this PR:

* Merge jobs `unix-test` and `windows-test`
* Add test for Emacs version `27.2` and `28.1`
* Remove `test/windows-bootstrap.el`
* Add `Eask`-file for CI test
* Add checkdoc test
* Add package-lint test